### PR TITLE
Use Ruby 3 on Alpine for Mailcatcher image

### DIFF
--- a/mailcatcher/Dockerfile
+++ b/mailcatcher/Dockerfile
@@ -1,10 +1,18 @@
-FROM helder/ruby:2.2
+FROM ruby:3.0-alpine
 
 LABEL maintainer="Monsieur Biz <docker@monsieurbiz.com>"
 
-RUN gem install mailcatcher --no-rdoc --no-ri
+RUN apk add --no-cache --virtual .build-dependencies \
+    build-base \
+    g++ \
+    make \
+    musl-dev \
+    openssl-dev \
+    sqlite-dev
+
+RUN gem install mailcatcher --no-document && \
+    rm -rf $GEM_HOME/cache/*
 
 EXPOSE 1025 1080
 
 CMD ["mailcatcher", "--smtp-ip=0.0.0.0", "--smtp-port=1025", "--http-ip=0.0.0.0", "--http-port=1080", "-f"]
-


### PR DESCRIPTION
This feature is useful to:
- Avoid this bug: https://github.com/sj26/mailcatcher/issues/482
- Reduce image size from ~750Mb to ~270MB