### PR TITLE
Fix old php images 

### DIFF
--- a/php/5/apache/Dockerfile
+++ b/php/5/apache/Dockerfile
@@ -2,6 +2,9 @@ FROM php:5-apache
 
 LABEL maintainer="Monsieur Biz <docker@monsieurbiz.com>"
 
+# Replace secure by archive
+RUN echo "deb [trusted=yes] http://archive.debian.org/debian/ stretch main non-free contrib\ndeb-src [trusted=yes] http://archive.debian.org/debian/ stretch main non-free contrib \ndeb [trusted=yes] http://archive.debian.org/debian-security/ stretch/updates main non-free contrib" > /etc/apt/sources.list
+
 # Install dependencies
 RUN apt-get update && apt-get install -y \
         libmcrypt4 \

--- a/php/5/cli/Dockerfile
+++ b/php/5/cli/Dockerfile
@@ -1,6 +1,9 @@
-FROM php:5-cli
+FROM php:5-cli-stretch
 
 LABEL maintainer="Monsieur Biz <docker@monsieurbiz.com>"
+
+# Replace secure by archive
+RUN echo "deb [trusted=yes] http://archive.debian.org/debian/ stretch main non-free contrib\ndeb-src [trusted=yes] http://archive.debian.org/debian/ stretch main non-free contrib \ndeb [trusted=yes] http://archive.debian.org/debian-security/ stretch/updates main non-free contrib" > /etc/apt/sources.list
 
 # Install dependencies
 RUN apt-get update && apt-get install -y \

--- a/php/5/fpm/Dockerfile
+++ b/php/5/fpm/Dockerfile
@@ -1,6 +1,9 @@
-FROM php:5-fpm
+FROM php:5-fpm-stretch
 
 LABEL maintainer="Monsieur Biz <docker@monsieurbiz.com>"
+
+# Replace secure by archive
+RUN echo "deb [trusted=yes] http://archive.debian.org/debian/ stretch main non-free contrib\ndeb-src [trusted=yes] http://archive.debian.org/debian/ stretch main non-free contrib \ndeb [trusted=yes] http://archive.debian.org/debian-security/ stretch/updates main non-free contrib" > /etc/apt/sources.list
 
 # Install dependencies
 RUN apt-get update && apt-get install -y \

--- a/php/7.0/apache/Dockerfile
+++ b/php/7.0/apache/Dockerfile
@@ -1,6 +1,9 @@
-FROM php:7.0-apache
+FROM php:7.0-apache-stretch
 
 LABEL maintainer="Monsieur Biz <docker@monsieurbiz.com>"
+
+# Replace secure by archive
+RUN echo "deb [trusted=yes] http://archive.debian.org/debian/ stretch main non-free contrib\ndeb-src [trusted=yes] http://archive.debian.org/debian/ stretch main non-free contrib \ndeb [trusted=yes] http://archive.debian.org/debian-security/ stretch/updates main non-free contrib" > /etc/apt/sources.list
 
 # Install dependencies
 RUN apt-get update && apt-get install -y \

--- a/php/7.0/cli/Dockerfile
+++ b/php/7.0/cli/Dockerfile
@@ -1,6 +1,9 @@
-FROM php:7.0-cli
+FROM php:7.0-cli-stretch
 
 LABEL maintainer="Monsieur Biz <docker@monsieurbiz.com>"
+
+# Replace secure by archive
+RUN echo "deb [trusted=yes] http://archive.debian.org/debian/ stretch main non-free contrib\ndeb-src [trusted=yes] http://archive.debian.org/debian/ stretch main non-free contrib \ndeb [trusted=yes] http://archive.debian.org/debian-security/ stretch/updates main non-free contrib" > /etc/apt/sources.list
 
 # Install dependencies
 RUN apt-get update && apt-get install -y \

--- a/php/7.0/fpm/Dockerfile
+++ b/php/7.0/fpm/Dockerfile
@@ -1,6 +1,9 @@
-FROM php:7.0-fpm
+FROM php:7.0-fpm-stretch
 
 LABEL maintainer="Monsieur Biz <docker@monsieurbiz.com>"
+
+# Replace secure by archive
+RUN echo "deb [trusted=yes] http://archive.debian.org/debian/ stretch main non-free contrib\ndeb-src [trusted=yes] http://archive.debian.org/debian/ stretch main non-free contrib \ndeb [trusted=yes] http://archive.debian.org/debian-security/ stretch/updates main non-free contrib" > /etc/apt/sources.list
 
 # Install dependencies
 RUN apt-get update && apt-get install -y \

--- a/php/7.1/apache/Dockerfile
+++ b/php/7.1/apache/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.1-apache
+FROM php:7.1-apache-buster
 
 LABEL maintainer="Monsieur Biz <docker@monsieurbiz.com>"
 

--- a/php/7.2/apache/Dockerfile
+++ b/php/7.2/apache/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.2-apache
+FROM php:7.2-apache-buster
 
 LABEL maintainer="Monsieur Biz <docker@monsieurbiz.com>"
 


### PR DESCRIPTION
Debian stretch is archived, so the sources for this release are available here:

```
deb http://archive.debian.org/debian stretch main
```

[Source](https://wiki.debian.org/DebianStretch#FAQ)