### PR TITLE
PHP 8.2: use buster to avoid an error on old server

### DIFF
--- a/php/8.2/apache/Dockerfile
+++ b/php/8.2/apache/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.2-apache-bullseye
+FROM php:8.2-apache-buster
 
 LABEL maintainer="Monsieur Biz <docker@monsieurbiz.com>"
 

--- a/php/8.2/cli/Dockerfile
+++ b/php/8.2/cli/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.2-cli-bullseye
+FROM php:8.2-cli-buster
 
 LABEL maintainer="Monsieur Biz <docker@monsieurbiz.com>"
 

--- a/php/8.2/fpm/Dockerfile
+++ b/php/8.2/fpm/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.2-fpm-bullseye
+FROM php:8.2-fpm-buster
 
 LABEL maintainer="Monsieur Biz <docker@monsieurbiz.com>"
 


### PR DESCRIPTION
On our server, it is not possible to use a recent debian release. We have this error:

```
[:crit] [pid 10] (38)Function not implemented: AH00141: Could not initialize random number generator
```

